### PR TITLE
Handle user commands with a switch statement

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -44,6 +44,37 @@ async Task HandleUpdateAsync(ITelegramBotClient botClient, Update update, Cancel
     if (message.Text is not { } messageText)
         return;
 
+
+
+    switch (messageText.ToLower())
+    {
+        case "/start":
+            // Reply with a welcome message for the "/start" command
+            var startMessage = "Yes I'm alive bitch !";
+            await botClient.SendTextMessageAsync(message.Chat.Id, startMessage, cancellationToken: cancellationToken);
+            break;
+
+        case "/help":
+            var helpMessage = "പോയിട്ട് അടുത്ത വെള്ളിയാഴ്ച്ച വാ";
+            await botClient.SendTextMessageAsync(message.Chat.Id, helpMessage, cancellationToken: cancellationToken);
+            break;
+
+        case "/about":
+            var aboutMessage = "C# Telegram Chat Bot built using .NET Client Telegram Bot API Framework";
+            await botClient.SendTextMessageAsync(message.Chat.Id, aboutMessage, cancellationToken: cancellationToken);
+            break;
+
+        case "/contact":
+            var contactMessage = "why are you gay ?";
+            await botClient.SendTextMessageAsync(message.Chat.Id, contactMessage, cancellationToken: cancellationToken);
+            break;
+
+        default:
+            // Handle unknown commands or other text messages here
+            break;
+    }
+
+
     //Send an introduction message with an InlineKeyboardMarkup
     Message newMessage = await botClient.SendTextMessageAsync(
     chatId: ChatId,
@@ -58,12 +89,14 @@ async Task HandleUpdateAsync(ITelegramBotClient botClient, Update update, Cancel
     cancellationToken: cancellationToken);
 
 
+
     // Display information about the sent message, including sender's name, message ID, local timestamp, reply status, and message entities count.
     Console.WriteLine(
     $"{newMessage.From.FirstName} sent message {newMessage.MessageId} " +
     $"to chat {newMessage.Chat.Id} at {newMessage.Date.ToLocalTime()}. " +
     $"It is a reply to message {newMessage.ReplyToMessage.MessageId} " +
     $"and has {newMessage.Entities.Length} message entities.");
+
 
 
     //var chatId = message.Chat.Id;


### PR DESCRIPTION
This commit adds a switch statement to handle various user commands. It includes
responses for the following commands:

- "/start": Sends a welcome message.
- "/help": Provides a help message.
- "/about": Shares information about the bot.
- "/contact": Responds with a specific message.

Additionally, a default case is included to handle unknown commands or other
text messages.

Each case sends an appropriate response message to the user's chat.